### PR TITLE
Fix Django serialization / deserialization

### DIFF
--- a/pgvector/django/__init__.py
+++ b/pgvector/django/__init__.py
@@ -39,6 +39,9 @@ class VectorField(Field):
     def get_prep_value(self, value):
         return to_db(value)
 
+    def value_to_string(self, obj):
+        return to_db(self.value_from_object(obj))
+
 
 class IvfflatIndex(PostgresIndex):
     suffix = 'ivfflat'


### PR DESCRIPTION
The `VectorField` currently breaks `dumpdata` and `loaddata` Django management commands, because the vector data is not being serialized to JSON properly.

Currently the serialization outputs look like this, where the numpy array was directly cast to a string:
```...{"embedding": "[1. 1. 1.]"}}...```

...but the deserializer expects something with commas between each float instead of just spaces.

This can be demonstrated by the following failing test:
``` 
   def test_serialization(self):
        create_items()
        items = Item.objects.all()
        data = serializers.serialize('json', items)
        with mock.patch('django.core.serializers.python.apps.get_model') as get_model:
            get_model.return_value = Item
            for obj in serializers.deserialize('json', data, ):
                obj.save()
 ```
 
 This PR adds the test above, and fixes the bug.
