### PR TITLE
Support the `peewee` ORM

### DIFF
--- a/pgvector/peewee/__init__.py
+++ b/pgvector/peewee/__init__.py
@@ -1,0 +1,42 @@
+from peewee import Expression, Field, Node, Value
+
+from pgvector.utils import from_db, to_db
+
+L2_DIST = ' <-> '
+MAX_INNER_PROD = ' <#> '
+COS_DIST = ' <=> '
+
+
+class VectorValue(Node):
+    def __init__(self, field, value):
+        self.field = field
+        self.value = value
+
+    def __sql__(self, ctx):
+        return (
+            ctx.sql(Value(self.value, unpack=False))
+            .literal('::' + self.field.field_type)
+        )
+
+
+class VectorField(Field):
+    field_type = 'VECTOR'
+
+    def __init__(self, *args, dimensions=None, **kwargs):
+        self.dimensions = dimensions
+        super().__init__(*args, **kwargs)
+
+    db_value = staticmethod(to_db)
+    python_value = staticmethod(from_db)
+
+    def _distance(self, vector, op):
+        return Expression(lhs=self, op=op, rhs=VectorValue(self, vector))
+
+    def l2_distance(self, vector):
+        return self._distance(vector, op=L2_DIST)
+
+    def cosine_distance(self, vector):
+        return self._distance(vector, op=COS_DIST)
+
+    def max_inner_product(self, vector):
+        return self._distance(vector, op=MAX_INNER_PROD)

--- a/tests/test_peewee.py
+++ b/tests/test_peewee.py
@@ -1,0 +1,92 @@
+from typing import Any
+
+import numpy as np
+import pytest
+from peewee import (
+    AutoField,
+    DatabaseProxy,
+    Model,
+    PostgresqlDatabase,
+)
+
+from pgvector.peewee import VectorField
+
+
+db_proxy = DatabaseProxy()
+
+class BaseModel(Model):
+    class Meta:
+        database = db_proxy
+
+
+class Item(BaseModel):
+    id = AutoField(primary_key=True)
+    embedding = VectorField()
+
+
+
+@pytest.fixture(name='pg_database', autouse=True)
+def fixture_pg_database():
+    db = PostgresqlDatabase('pgvector_python_test', host='localhost')
+    db_proxy.initialize(db)
+
+    models = BaseModel.__subclasses__()
+    db.bind(models, bind_refs=False, bind_backrefs=False)
+
+    db.connect()
+    db.create_tables(models)
+
+    db.execute_sql('CREATE EXTENSION IF NOT EXISTS vector')
+
+    for model in models:
+        model.truncate_table()
+
+    yield db
+
+    for model in models:
+        model.truncate_table()
+
+    db.close()
+
+
+
+def test_select(pg_database: PostgresqlDatabase):
+    assert pg_database.execute_sql('SELECT 1').fetchone() == (1,)
+
+
+@pytest.mark.parametrize('vector', [[1, 2, 3], np.array([1, 2, 3])], ids=['list', 'np'])
+def test_create_vector(vector: Any):
+    item = Item.create(embedding=vector)
+    assert Item.get_by_id(item.id) == item
+
+
+def test_l2_distance_sort():
+    item1 = Item.create(embedding=[1, 2, 3])
+    item2 = Item.create(embedding=[4, 5, 6])
+    item3 = Item.create(embedding=[0, 0, 0])
+
+    query = (
+        Item.select()
+        .where(Item.id != item1.id)
+        .order_by(Item.embedding.l2_distance(item1.embedding).desc())
+    )
+
+    items = list(query)
+    assert items == [item2, item3]
+
+
+@pytest.mark.parametrize(
+    argnames=['method', 'expected'],
+    argvalues=[
+        (Item.embedding.l2_distance, 5.196152422706632),
+        (Item.embedding.cosine_distance, 0.025368153802923787),
+        (Item.embedding.max_inner_product, -32.0),
+    ],
+    ids=['l2_distance', 'cosine_distance', 'max_inner_prod'],
+)
+def test_distance_measures(method: Any, expected: float):
+    item = Item.create(embedding=[1, 2, 3])
+    vector = [4, 5, 6]
+
+    measure = Item.select(method(vector).alias('dist')).where(Item.id == item.id).get()
+    assert measure.dist == expected


### PR DESCRIPTION
Feature request [here](https://github.com/pgvector/pgvector-python/issues/26).

Adds:

- [x] Support declaring `VectorField`s and basic distance metrics
- [x] ~Support vector-based indexes~
