### PR TITLE
Registering Vector Type with SQLAlchemy Registries

### DIFF
--- a/pgvector/sqlalchemy/__init__.py
+++ b/pgvector/sqlalchemy/__init__.py
@@ -37,4 +37,4 @@ class Vector(UserDefinedType):
             return self.op('<=>', return_type=Float)(other)
 
 # Register Vector type to PostgreSQL's reflection subsystem
-postgresql.base.ischema_names['VECTOR'] = Vector
+postgresql.base.ischema_names['vector'] = Vector

--- a/pgvector/sqlalchemy/__init__.py
+++ b/pgvector/sqlalchemy/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy.types import UserDefinedType, Float
 from ..utils import from_db, to_db
-
+from sqlalchemy.dialects import postgresql
 __all__ = ['Vector']
 
 
@@ -35,3 +35,6 @@ class Vector(UserDefinedType):
 
         def cosine_distance(self, other):
             return self.op('<=>', return_type=Float)(other)
+
+# Register Vector type to PostgreSQL's reflection subsystem
+postgresql.base.ischema_names['VECTOR'] = Vector


### PR DESCRIPTION
Hi,

I've created a pull request that adds the necessary code to register the Vector type to SQLAlchemy's type registries. This enhancement ensures compatibility with the sqlacodegen tool, allowing for smoother integration and improved usability.

Please review and merge at your earliest convenience.

Thanks 😊