### PR TITLE
Fix the SQLAlchemy Item class

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Add a vector column
 from pgvector.sqlalchemy import Vector
 
 class Item(Base):
+    __tablename__ = "items"
+    id: Mapped[int] = mapped_column(primary_key=True)
     embedding = mapped_column(Vector(3))
 ```
 


### PR DESCRIPTION
This PR adds a table name and an `id` column to the `Item` class in the SQLAlchemy model. Otherwise SQLAlchemy throws errors.