### PR TITLE
Add save to test

### DIFF
--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -109,6 +109,7 @@ class TestDjango:
         assert item.id == 1
         assert np.array_equal(item.embedding, np.array([1, 2, 3]))
         assert item.embedding.dtype == np.float32
+        item.save()
 
     def test_l2_distance(self):
         create_items()


### PR DESCRIPTION
This currently breaks for me,
so ensure it isn't totally broken in the tests:

Test case:

```
>>> url = AnalyzedUrl.objects.filter(embedding__isnull=False).first()
>>> len(url.embedding)
384
>>> url.save()
Traceback (most recent call last):
  File "/usr/lib/python3.10/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/home/django/checkouts/ethical-ad-server/adserver/analyzer/models.py", line 64, in save
    self.full_clean()
  File "/home/django/lib/python3.10/site-packages/django/db/models/base.py", line 1470, in full_clean
    self.clean_fields(exclude=exclude)
  File "/home/django/lib/python3.10/site-packages/django/db/models/base.py", line 1519, in clean_fields
    if f.blank and raw_value in f.empty_values:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Model:

```
   embedding = VectorField(dimensions=384, default=None, null=True, blank=True)
```