### PR TITLE
Support registration via psycopg2.extras cursor factories

### DIFF
--- a/pgvector/psycopg2/register.py
+++ b/pgvector/psycopg2/register.py
@@ -4,12 +4,21 @@ from .sparsevec import register_sparsevec_info
 from .vector import register_vector_info
 
 
+def get_type_info(cur):
+    # use to_regtype to get first matching type in search path
+    cur.execute("SELECT typname, oid FROM pg_type WHERE oid IN (to_regtype('vector'), to_regtype('halfvec'), to_regtype('sparsevec'))")
+    results = cur.fetchall()
+
+    try:
+        return {r[0]: r[1] for r in results}
+    except KeyError:
+        return {r['typname']: r['oid'] for r in results}
+
+
 def register_vector(conn_or_curs=None):
     cur = conn_or_curs.cursor() if hasattr(conn_or_curs, 'cursor') else conn_or_curs
 
-    # use to_regtype to get first matching type in search path
-    cur.execute("SELECT typname, oid FROM pg_type WHERE oid IN (to_regtype('vector'), to_regtype('halfvec'), to_regtype('sparsevec'))")
-    type_info = dict(cur.fetchall())
+    type_info = get_type_info(cur)
 
     if 'vector' not in type_info:
         raise psycopg2.ProgrammingError('vector type not found in the database')


### PR DESCRIPTION
The current registration logic assumes cursors are created using the default cursor factory.
This patch adds support for [other factories provided shipped in `psycopg2.extras`](https://www.psycopg.org/docs/extras.html#connection-and-cursor-subclasses)

Please let me know what you think, or if there's anything that you'd like changed