### PR TITLE
Add support for Cosine Similarity

### DIFF
--- a/pgvector/django/__init__.py
+++ b/pgvector/django/__init__.py
@@ -1,6 +1,6 @@
 from .bit import BitField
 from .extensions import VectorExtension
-from .functions import L2Distance, MaxInnerProduct, CosineDistance, L1Distance, HammingDistance, JaccardDistance
+from .functions import L2Distance, MaxInnerProduct, CosineDistance, CosineSimilarity, L1Distance, HammingDistance, JaccardDistance
 from .halfvec import HalfVectorField
 from .indexes import IvfflatIndex, HnswIndex
 from .sparsevec import SparseVectorField

--- a/pgvector/django/functions.py
+++ b/pgvector/django/functions.py
@@ -38,6 +38,14 @@ class MaxInnerProduct(DistanceBase):
 class CosineDistance(DistanceBase):
     function = ''
     arg_joiner = ' <=> '
+    
+class CosineSimilarity(DistanceBase):
+    function = ''
+    arg_joiner = ' <=> '
+    
+    def as_sql(self, compiler, connection):
+        sql, params = super().as_sql(compiler, connection)
+        return f"1 - ({sql})", params
 
 
 class L1Distance(DistanceBase):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -12,7 +12,7 @@ from math import sqrt
 import numpy as np
 import os
 import pgvector.django
-from pgvector.django import VectorExtension, VectorField, HalfVectorField, BitField, SparseVectorField, IvfflatIndex, HnswIndex, L2Distance, MaxInnerProduct, CosineDistance, L1Distance, HammingDistance, JaccardDistance, HalfVector, SparseVector
+from pgvector.django import VectorExtension, VectorField, HalfVectorField, BitField, SparseVectorField, IvfflatIndex, HnswIndex, L2Distance, MaxInnerProduct, CosineDistance, CosineSimilarity, L1Distance, HammingDistance, JaccardDistance, HalfVector, SparseVector
 from unittest import mock
 
 settings.configure(
@@ -190,6 +190,13 @@ class TestDjango:
         items = Item.objects.annotate(distance=distance).order_by(distance)
         assert [v.id for v in items] == [1, 2, 3]
         assert [v.distance for v in items] == [0, 0, 0.05719095841793653]
+        
+    def test_vector_cosine_similarity(self):     
+        create_items()
+        similarity = CosineSimilarity('embedding', [1, 1, 1])
+        items = Item.objects.annotate(similarity=similarity).order_by('-similarity')
+        assert [v.id for v in items] == [1, 2, 3]
+        assert [v.similarity for v in items] == [1.0, 1.0, 0.9428090415820635]
 
     def test_vector_l1_distance(self):
         create_items()

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -230,6 +230,13 @@ class TestDjango:
         items = Item.objects.annotate(distance=distance).order_by(distance)
         assert [v.id for v in items] == [1, 2, 3]
         assert [v.distance for v in items] == [0, 0, 0.05719095841793653]
+        
+    def test_halfvec_cosine_similarity(self):
+        create_items()
+        similarity = CosineSimilarity('half_embedding', HalfVector([1, 1, 1]))
+        items = Item.objects.annotate(similarity=similarity).order_by('-similarity')
+        assert [v.id for v in items] == [1, 2, 3]
+        assert [v.similarity for v in items] == [1.0, 1.0, 0.9428090415820635]
 
     def test_halfvec_l1_distance(self):
         create_items()
@@ -282,6 +289,13 @@ class TestDjango:
         items = Item.objects.annotate(distance=distance).order_by(distance)
         assert [v.id for v in items] == [1, 2, 3]
         assert [v.distance for v in items] == [0, 0, 0.05719095841793653]
+        
+    def test_sparsevec_cosine_similarity(self):
+        create_items()
+        similarity = CosineSimilarity('sparse_embedding', SparseVector([1, 1, 1]))
+        items = Item.objects.annotate(similarity=similarity).order_by('-similarity')
+        assert [v.id for v in items] == [1, 2, 3]
+        assert [v.similarity for v in items] == [1.0, 1.0, 0.9428090415820635]
 
     def test_sparsevec_l1_distance(self):
         create_items()


### PR DESCRIPTION
This pull request introduces a new `CosineSimilarity` function to the `pgvector` Django integration and updates the corresponding tests. The most important changes include adding the `CosineSimilarity` function, updating imports, and adding a new test case for `CosineSimilarity`.

`CosineSimilarity` must be useful for people who are wondering to use similarity instead of distance.

New feature addition:

* [`pgvector/django/functions.py`](diffhunk://#diff-69cb74225b65f4561f9cab4b454dc4b2d2e7bc9301baa7e82aab7208d769d6e9R42-R49): Added a new class `CosineSimilarity` that inherits from `DistanceBase` and overrides the `as_sql` method to compute cosine similarity.

Import updates:

* [`pgvector/django/__init__.py`](diffhunk://#diff-28a96b695725de1f44dcb0510630872f9bebcbadb9df956beae5e382287653d6L3-R3): Updated the import statement to include the new `CosineSimilarity` function.
* [`tests/test_django.py`](diffhunk://#diff-930917b71eb0da934428d418379a43488873ea091eb29b1ea0450b242653d9e5L15-R15): Updated the import statement to include the new `CosineSimilarity` function.

Test updates:

* [`tests/test_django.py`](diffhunk://#diff-930917b71eb0da934428d418379a43488873ea091eb29b1ea0450b242653d9e5R194-R200): Added
This pull request introduces a new `CosineSimilarity` function to the `pgvector` Django package, along with corresponding tests. The changes primarily involve adding this new function and ensuring it is properly tested across different vector types.

### Key Changes:

#### New Functionality:
* Added `CosineSimilarity` class to `pgvector/django/functions.py` to calculate cosine similarity.

#### Import Adjustments:
* Updated imports in `pgvector/django/__init__.py` to include `CosineSimilarity`.
* Updated imports in `tests/test_django.py` to include `CosineSimilarity`.

#### Testing Enhancements:
* Added `test_vector_cosine_similarity` method to test cosine similarity for regular vectors in `tests/test_django.py`.
* Added `test_halfvec_cosine_similarity` method to test cosine similarity for half vectors in `tests/test_django.py`.
* Added `test_sparsevec_cosine_similarity` method to test cosine similarity for sparse vectors in `tests/test_django.py`.