### PR TITLE
Fix missing import in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Or check out some examples:
 Create a migration to enable the extension
 
 ```python
+from django.db import migrations
 from pgvector.django import VectorExtension
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Without this, the example migration fails with the error message

> NameError: name 'migrations' is not defined