### PR TITLE
Fix TypeError: 'float' object is not subscriptable for Sqlalchemy core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2 (2025-06-09)
+
+- Add support for `list[float]` returned from db query when using sqlalchemy core
+
 ## 0.4.1 (2025-04-26)
 
 - Fixed `SparseVector` constructor for SciPy sparse matrices

--- a/pgvector/vector.py
+++ b/pgvector/vector.py
@@ -70,14 +70,14 @@ class Vector:
 
     @classmethod
     def _from_db(cls, value):
-        if value is None or isinstance(value, np.ndarray):
+        if value is None or isinstance(value, float) or isinstance(value, np.ndarray):
             return value
 
         return cls.from_text(value).to_numpy().astype(np.float32)
 
     @classmethod
     def _from_db_binary(cls, value):
-        if value is None or isinstance(value, np.ndarray):
+        if value is None or isinstance(value, float) or isinstance(value, np.ndarray):
             return value
 
         return cls.from_binary(value).to_numpy().astype(np.float32)


### PR DESCRIPTION
Here’s a properly formatted GitHub issue in Markdown that you can use to report the problem:

---

## Bug Report: `TypeError: 'float' object is not subscriptable` when performing cosine vector search

### Summary

When performing a cosine distance vector search using SQLAlchemy with the following code:

```python
query_vector = sa.literal(embedding, type_=VECTOR)
query = sa.select(
    (o.embedding_table.c.embedding_vector.op('<->')(query_vector)).label("cosine_distance")
).order_by(sa.asc("cosine_distance")).limit(1)
```

A `TypeError` is raised:

```
TypeError: 'float' object is not subscriptable
```

### Details

The issue occurs because SQLAlchemy attempts to process the result using `Vector._from_db`, which is not appropriate for a scalar float result (i.e., the cosine distance). `Vector._from_db` expects a structure like an array or list, but receives a float from the database, leading to the error.

This line appears to be the source of the issue:

```python
# Inside result_processor or similar internal hook
Vector._from_db(<float_value>)
```
