### PR TITLE
Add other input types for SQLAlchemy models

### DIFF
--- a/pgvector/bit.py
+++ b/pgvector/bit.py
@@ -62,9 +62,12 @@ class Bit:
 
     @classmethod
     def _to_db(cls, value):
+        if value is None:
+            return value 
+        
         if not isinstance(value, cls):
-            raise ValueError('expected bit')
-
+            value = cls(value)
+        
         return value.to_text()
 
     @classmethod
@@ -73,3 +76,9 @@ class Bit:
             raise ValueError('expected bit')
 
         return value.to_binary()
+
+    @classmethod
+    def _from_db(cls, value):
+        if value is None or isinstance(value, cls): 
+            return value
+        return cls.from_text(value)

--- a/pgvector/sqlalchemy/bit.py
+++ b/pgvector/sqlalchemy/bit.py
@@ -1,6 +1,8 @@
+import asyncpg
+from sqlalchemy.dialects.postgresql.asyncpg import PGDialect_asyncpg
 from sqlalchemy.dialects.postgresql.base import ischema_names
 from sqlalchemy.types import UserDefinedType, Float
-
+from .. import Bit
 
 class BIT(UserDefinedType):
     cache_ok = True
@@ -13,6 +15,21 @@ class BIT(UserDefinedType):
         if self.length is None:
             return 'BIT'
         return 'BIT(%d)' % self.length
+
+    def bind_processor(self, dialect):
+        def process(value):
+            value = Bit._to_db(value)
+            if value and isinstance(dialect, PGDialect_asyncpg): 
+                return asyncpg.BitString(value)
+            return value
+        return process
+    
+    def result_processor(self, dialect, coltype):
+        def process(value): 
+            if value and isinstance(dialect, PGDialect_asyncpg):
+                return value.as_string()
+            return Bit._from_db(value).to_text() 
+        return process
 
     class comparator_factory(UserDefinedType.Comparator):
         def hamming_distance(self, other):

--- a/pgvector/sqlalchemy/bit.py
+++ b/pgvector/sqlalchemy/bit.py
@@ -26,8 +26,10 @@ class BIT(UserDefinedType):
     
     def result_processor(self, dialect, coltype):
         def process(value): 
-            if value and isinstance(dialect, PGDialect_asyncpg):
-                return value.as_string()
+            if value is None: return None
+            else: 
+                if isinstance(dialect, PGDialect_asyncpg): 
+                    return value.as_string()
             return Bit._from_db(value).to_text() 
         return process
 

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -591,7 +591,7 @@ class TestSqlalchemyAsync:
 
         async with async_session() as session:
             async with session.begin():
-                embedding = asyncpg.BitString('101') if engine == asyncpg_engine else '101'
+                embedding = '101'
                 session.add(Item(id=1, binary_embedding=embedding))
                 item = await session.get(Item, 1)
                 assert item.binary_embedding == embedding


### PR DESCRIPTION
Hi, 

First of all, thank you for the great library @ankane! 

I'm opening this PR to address some issues that have been raised by users (#84,  #110 and #112), that is to input types other than string in the `BIT` SQLAlchemy model (also when using the `asyncpg` dialect). In brief, given: 

```
class Item(Base):
    id = mapped_column(Integer, primary_key=True)
    binary_embedding = mapped_column(BIT(3))
```   

You can add it to your database using whatever input you like (and this will be transformed following the logic already present in the `init` of the `Bit` class): 

```
with Session(engine) as session: 
   session.add(Item(id = 1, 
   binary_embedding = [True, False, True])) # or [1, 0, 1], or np.array([1, 0, 1]) 
```