### PR TITLE
fix(halfvec): return numpy array from _from_db and _from_db_binary

### DIFF
--- a/pgvector/halfvec.py
+++ b/pgvector/halfvec.py
@@ -70,14 +70,14 @@ class HalfVector:
 
     @classmethod
     def _from_db(cls, value):
-        if value is None or isinstance(value, cls):
+        if value is None or isinstance(value, np.ndarray):
             return value
 
-        return cls.from_text(value)
+        return cls.from_text(value).to_numpy().astype(np.float16)
 
     @classmethod
     def _from_db_binary(cls, value):
-        if value is None or isinstance(value, cls):
+        if value is None or isinstance(value, np.ndarray):
             return value
 
-        return cls.from_binary(value)
+        return cls.from_binary(value).to_numpy().astype(np.float16)


### PR DESCRIPTION
Ensure consistency between `Vector` and `HalfVector` by having both return `numpy` arrays from `_from_db` and `_from_db_binary`. This change removes the special-case behavior of `HalfVector` returning itself, aligning it with `Vector`'s handling of database values.

Returning `NumPy` arrays ensures predictable behavior across embedding types and improves compatibility with libraries expecting standard array-like structures.
